### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ License & Authors
 - Author:: Thomas A. McGonagle
 
 ```text
-Copyright:: 2014, Booz Allen Hamilton
+Copyright:: 2015, Booz Allen Hamilton
 
 For more information on the license, please refer to the LICENSE file in the repo
 ```


### PR DESCRIPTION
Updated README.md, fixed bug stating that the copyright for the software was 2014 instead of 2015.
