### PR TITLE
Uses openssl cookbook 

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'openssl'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,9 +9,10 @@ default['postgresql']['version'] = '9.4'
 default['sampledata'] = true
 
 # Our random api secret key
-# @todo this should be randomly generated on run (use OpenSSL cookbook to do this)
-default['rdkey'] = 'd2924512f097d80a1c33cfa416c01cfe93b90912b83ad8dd254205e83915979e3bb08d38cad2e43dcd6db2f4aea53d8c6c41545dc6daaa50dbca9cc7f2612342'
+self.class.send(:include, Opscode::OpenSSL::Password)
+default['rdkey'] = secure_password(128)
 
+pp "Key: #{default['rdkey']}"
 # The Rails Enviroment to use
 default['rails_env'] = 'production'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,5 @@ version '1.1.0'
 
 supports 'centos', '~> 6.0'
 supports 'rhel', '~> 6.0'
+
+depends 'openssl'


### PR DESCRIPTION
Switched to OpenSSL Cookbook 'secure_password' to generate the key for ruby on the fly, closes #44 
